### PR TITLE
Updated dependency

### DIFF
--- a/btckey/btckey.go
+++ b/btckey/btckey.go
@@ -7,7 +7,7 @@ package btckey
 
 import (
 	"bytes"
-	"code.google.com/p/go.crypto/ripemd160"
+	"golang.org/x/crypto/ripemd160"
 	"crypto/sha256"
 	"fmt"
 	"io"


### PR DESCRIPTION
Changed import from "code.google.com/p/go.crypto/ripemd160", which no longer exists, to "golang.org/x/crypto/ripemd160".